### PR TITLE
Fix invalid type for 'keys' parameter in 'bulk_delete'

### DIFF
--- a/src/collections/keys.ts
+++ b/src/collections/keys.ts
@@ -18,7 +18,7 @@ export class Keys extends BaseCollection {
                        this.handleReject, keys, 'projects/{!:project_id}/keys');
  }
 
- bulk_delete(keys: number[] | string[], params: StandartParams) : any {
+ bulk_delete(keys: BulkUpdateKeysParams, params: StandartParams) : any {
    return this.createPromise('DELETE', params, this.returnBareJSON, this.handleReject, keys,
                              'projects/{!:project_id}/keys');
  }


### PR DESCRIPTION
It seems like `keys` parameter needs to be an object with an array called 'keys' nested inside to work, like the `bulk_update` method, so reusing the same interface should work.

Calling `bulk_delete` with the first parameter as a `number[]` or `string[]` causes a crash because of some unhandled promise rejection.