### PR TITLE
Changing typing for plural_format

### DIFF
--- a/src/interfaces/download_file_params.ts
+++ b/src/interfaces/download_file_params.ts
@@ -20,7 +20,7 @@ export interface DownloadFileParams {
   filter_repositories?: any[];
   replace_breaks?: boolean;
   disable_references?: boolean;
-  plural_format?: string[];
+  plural_format?: string;
   placeholder_format?: string;
   webhook_url?: string;
   language_mapping?: object;


### PR DESCRIPTION
### Summary

We assume that `plural_format` should actually be a string and not an array. Using an array will let the API fail.
```js
{ 
    message: 'Unknown `plural_format` 
    value', code: 400 
}
```