### PR TITLE
Fix reference to ambient URL interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -348,7 +348,7 @@ declare module "@lokalise/node-api" {
   }
 
   export class ApiRequest {
-    private urlRoot: string | URL;
+    private urlRoot: NonNullable<Options["prefixUrl"]>;
     promise: Promise<any>;
     params: StandartParams;
     constructor(

--- a/src/http_client/base.ts
+++ b/src/http_client/base.ts
@@ -5,7 +5,7 @@ import { LokaliseApi } from "../lokalise/lokalise";
 import { StandartParams } from "../interfaces/standart_params";
 
 export class ApiRequest {
-  private urlRoot: string | URL = "https://api.lokalise.com/api2/";
+  private urlRoot: NonNullable<Options["prefixUrl"]> = "https://api.lokalise.com/api2/";
   public promise: Promise<any>;
   public params: StandartParams = {};
 


### PR DESCRIPTION
### Summary

With an attempted update to `v6.0.0` recently, we've encountered the following error on our project:

```
> node_modules/@lokalise/node-api/index.d.ts:351:31 - error TS2304: Cannot find name 'URL'.
```

I've noticed that the types for `urlRoot` referring to the ambient URL interface, which by default doesn't exist unless `lib: ["dom"]` is added to the `tsconfig.json`, and I'm assuming that was not really the intent here.

The URL interface also exists within the Node types, but they have to be manually imported and referenced to be used.

However, since the intent seems to be to pass `urlRoot` to `prefixUrl` in Got options, I've just referenced the `Options["prefixUrl"]` and made it non-nullable.