### PR TITLE
Move Typescript to a devDependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 node_js:
-  - '10'
   - '11'
   - '12'
   - '13'
   - '14'
   - '15'
+  - '16'
 after_success:
 - codecov

--- a/docs/additional_info/changelog.md
+++ b/docs/additional_info/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+* Test with Node 16
+* Do not test with Node 10 that has reached its EOL 
+
 ## 6.2.0 (28-Apr-21)
 
 * Added `task_id` for `Translation`

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "6.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "got": "^11.8.1",
-        "typescript": "^4.1.3"
+        "got": "^11.8.1"
       },
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.1",
@@ -33,7 +32,8 @@
         "nyc": "^15.1",
         "prettier": "^2.2.1",
         "source-map-support": "^0.5.19",
-        "ts-node": "^9.1.1"
+        "ts-node": "^9.1.1",
+        "typescript": "^4.2.4"
       },
       "engines": {
         "node": ">=10"
@@ -4110,6 +4110,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
       "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7465,7 +7466,8 @@
     "typescript": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg=="
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lokalise/node-api",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lokalise/node-api",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "got": "^11.8.1",
@@ -669,8 +669,7 @@
     "node_modules/@types/node": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.1.tgz",
-      "integrity": "sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA==",
-      "license": "MIT"
+      "integrity": "sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA=="
     },
     "node_modules/@types/responselike": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "nyc": "^15.1",
     "prettier": "^2.2.1",
     "source-map-support": "^0.5.19",
-    "ts-node": "^9.1.1"
+    "ts-node": "^9.1.1",
+    "typescript": "^4.2.4"
   },
   "dependencies": {
-    "got": "^11.8.1",
-    "typescript": "^4.1.3"
+    "got": "^11.8.1"
   },
   "bugs": {
     "url": "https://github.com/lokalise/node-lokalise-api/issues"


### PR DESCRIPTION
### Summary

Moving typescript from a dependency to a devDependency as referenced in this issue https://github.com/lokalise/node-lokalise-api/issues/144

### Other Information

This PR is for general good house keeping and resolves an issue on my project where I didn't want to bundle typescript with the rest of my production code