### PR TITLE
Update language mapping to be correct

### DIFF
--- a/dist/interfaces/download_file_params.d.ts
+++ b/dist/interfaces/download_file_params.d.ts
@@ -1,3 +1,4 @@
+import { LanguageMapping } from './language_mapping';
 export interface DownloadFileParams {
     format: string;
     original_filenames?: boolean;
@@ -23,7 +24,7 @@ export interface DownloadFileParams {
     plural_format?: string;
     placeholder_format?: string;
     webhook_url?: string;
-    language_mapping?: object;
+    language_mapping?: LanguageMapping[];
     icu_numeric?: boolean;
     escape_percent?: boolean;
     indentation?: string;

--- a/src/interfaces/download_file_params.ts
+++ b/src/interfaces/download_file_params.ts
@@ -1,3 +1,5 @@
+import { LanguageMapping } from './language_mapping';
+
 export interface DownloadFileParams {
   format: string;
   original_filenames?: boolean;
@@ -23,7 +25,7 @@ export interface DownloadFileParams {
   plural_format?: string;
   placeholder_format?: string;
   webhook_url?: string;
-  language_mapping?: object;
+  language_mapping?: LanguageMapping[];
   icu_numeric?: boolean;
   escape_percent?: boolean;
   indentation?: string;

--- a/src/interfaces/language_mapping.ts
+++ b/src/interfaces/language_mapping.ts
@@ -1,0 +1,4 @@
+export interface LanguageMapping {
+    original_language_iso: string;
+    custom_language_iso: string;
+}


### PR DESCRIPTION
### Summary

The type declaration for `DownloadFileParams` erroneously declare the `language_mapping` to be an object when it is actually an array of objects.

This updates the typing both to properly declare the object shape and that an array of objects must be supplied.

### Other Information

The docs here are also wrong: https://app.lokalise.com/api2docs/curl/#transition-download-files-post