### PR TITLE
fix: add missing close_language to languages of UpdateTaskParams

### DIFF
--- a/src/collections/tasks.ts
+++ b/src/collections/tasks.ts
@@ -9,16 +9,18 @@ interface ListTaskParams extends ProjectWithPagination {
   filter_statuses?: string;
 }
 
+type TaskLanguage = {
+  language_iso: string;
+  users?: string[] | number[];
+  groups?: string[] | number[];
+}
+
 type CreateTaskParams = {
   title: string;
   description?: string;
   due_date?: string;
   keys?: string[] | number[];
-  languages?: Array<{
-    language_iso: string;
-    users?: string[] | number[];
-    groups?: string[] | number[];
-  }>;
+  languages?: Array<TaskLanguage>;
   source_language_iso?: string;
   auto_close_languages?: boolean;
   auto_close_task?: boolean;
@@ -41,6 +43,9 @@ type UpdateTaskParams = Omit<
 > & {
   title?: string;
   close_task?: boolean;
+  languages?: Array<TaskLanguage & {
+    close_language?: boolean;
+  }>
 };
 
 type TaskDeleted = {


### PR DESCRIPTION
### Summary

According to the API reference of the Update Task API endpoint, the `languages` array of the `UpdateTaskParams` can have a `close_language` property. This PR adds it to the `UpdateTaskParams`.

To not duplicate the properties of the languages, I moved them into a separate type `TaskLanguage`.