### PR TITLE
throw proper error instead of json parse error

### DIFF
--- a/src/http_client/base.ts
+++ b/src/http_client/base.ts
@@ -65,10 +65,18 @@ export class ApiRequest {
     try {
       const response = await fetch(target, options);
       let responseJSON;
-      if (response.status === 204) {
-        responseJSON = null;
-      } else {
-        responseJSON = await response.json();
+
+      try {
+        if (response.status === 204) {
+          responseJSON = null;
+        } else {
+          responseJSON = await response.json();
+        }
+      } catch (error) {
+        return Promise.reject({
+          message: response.statusText,
+          code: response.status,
+        });
       }
 
       if (response.ok) {

--- a/test/lokalise/lokalise_api.spec.ts
+++ b/test/lokalise/lokalise_api.spec.ts
@@ -18,7 +18,7 @@ describe("LokaliseApi", function () {
     expect(client.clientData.version).to.eq("api2");
   });
 
-  it.only("is expected to reject with proper http message and status code if json is not parsable", async function () {
+  it("is expected to reject with proper http message and status code if json is not parsable", async function () {
     const mockAgent = new MockAgent();
     setGlobalDispatcher(mockAgent);
     const mockPool = mockAgent.get("https://api.lokalise.com");


### PR DESCRIPTION
### Summary

Lokalise can return HTTP 429 Too many requests status due its rate limiter. When this happens `await response.json()` is unable to parse since its not getting json text and its throwing error `Unexpected token '<', "<html>\r\n<h"... is not valid JSON`.

When json parse fails sdk should return response status message and status code in order to better handle thrown error.