### PR TITLE
feat: Add marketing_integrations project type support

### DIFF
--- a/src/types/projects.ts
+++ b/src/types/projects.ts
@@ -13,7 +13,7 @@ export type CreateProjectParams = {
 		| "localization_files"
 		| "paged_documents"
 		| "marketing"
-		| "content_integration";
+		| "marketing_integrations";
 	is_segmentation_enabled?: boolean;
 };
 


### PR DESCRIPTION
### Summary

Exposing new project type called `marketing_integrations`. As part of the previous PR https://github.com/lokalise/node-lokalise-api/pull/526 I've exposed a wrong one, so let's delete it as well.