### PR TITLE
PERF-2500: added new key to files in the API

### DIFF
--- a/docs/api/files.md
+++ b/docs/api/files.md
@@ -71,7 +71,7 @@ process = await lokaliseApi.files().upload(project_id,
 process.status; // => 'queued'
 ```
 
-Asynchronous upload will return a [`QueuedProcess`](#queued-processes) containing process ID, status of the process (`queued`, `finished`, `failed` etc) and some other info. You may periodically check the status of the process by using `get()` method:
+Asynchronous upload will return a [`QueuedProcess`](https://lokalise.github.io/node-lokalise-api/api/queued-processes) containing process ID, status of the process (`queued`, `finished`, `failed` etc) and some other info. You may periodically check the status of the process by using `get()` method:
 
 ```js
 process = await lokaliseApi.files().upload(project_id,
@@ -95,7 +95,7 @@ process = await lokaliseApi.files().uploadFromFss(project_id,
 process.status; // => 'queued'
 ```
 
-Like the regular upload, it returns a [`QueuedProcess`](#queued-processes) that you can poll with `queuedProcesses().get()`.
+Like the regular upload, it returns a [`QueuedProcess`](https://lokalise.github.io/node-lokalise-api/api/queued-processes) that you can poll with `queuedProcesses().get()`.
 
 ## Delete translation file
 

--- a/docs/api/files.md
+++ b/docs/api/files.md
@@ -84,6 +84,19 @@ process = await lokaliseApi.queuedProcesses().get(process.process_id, { project_
 process.status // => 'finished'
 ```
 
+## Upload translation file from file storage
+
+Imports a file previously uploaded to the Lokalise file storage service (FSS). Instead of passing the file content as base64-encoded `data`, the file is referenced by its storage file ID. The referenced file must have been stored owner-scoped under the same project ID with the `importViaMCP` use case. In all other aspects the endpoint behaves the same as the regular upload.
+
+```js
+process = await lokaliseApi.files().uploadFromFss(project_id,
+  {fss_file_id: 'fss_file_id', filename: 'test1.json', lang_iso: 'en'}
+);
+process.status; // => 'queued'
+```
+
+Like the regular upload, it returns a [`QueuedProcess`](#queued-processes) that you can poll with `queuedProcesses().get()`.
+
 ## Delete translation file
 
 [API doc](https://developers.lokalise.com/reference/delete-a-file)

--- a/src/collections/files.ts
+++ b/src/collections/files.ts
@@ -7,6 +7,7 @@ import type {
 	DownloadFileParams,
 	FileDeleted,
 	ListFileParams,
+	UploadFileFromFssParams,
 	UploadFileParams,
 } from "../types/files.js";
 import { warn } from "../utils/logger.js";
@@ -62,6 +63,19 @@ export class Files extends BaseCollection<File, QueuedProcess> {
 			this.populateSecondaryObjectFromJsonRoot,
 			upload,
 			"projects/{!:project_id}/files/upload",
+		);
+	}
+
+	uploadFromFss(
+		project_id: string,
+		upload: UploadFileFromFssParams,
+	): Promise<QueuedProcess> {
+		return this.createPromise(
+			"POST",
+			{ project_id },
+			this.populateSecondaryObjectFromJsonRoot,
+			upload,
+			"projects/{!:project_id}/files/upload-from-fss",
 		);
 	}
 

--- a/src/types/files.ts
+++ b/src/types/files.ts
@@ -141,6 +141,10 @@ export interface UploadFileParams {
 	filter_task_id?: number;
 }
 
+export type UploadFileFromFssParams = Omit<UploadFileParams, "data"> & {
+	fss_file_id: string;
+};
+
 export type ListFileParams = ProjectWithPagination & {
 	filter_filename?: string;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,7 @@ export type {
 	DownloadFileParams,
 	FileDeleted,
 	ListFileParams,
+	UploadFileFromFssParams,
 	UploadFileParams,
 } from "./files.js";
 export type {

--- a/test/files/files.spec.ts
+++ b/test/files/files.spec.ts
@@ -1,4 +1,8 @@
-import type { DownloadFileParams, UploadFileParams } from "../../src/main.js";
+import type {
+	DownloadFileParams,
+	UploadFileFromFssParams,
+	UploadFileParams,
+} from "../../src/main.js";
 import { QueuedProcess } from "../../src/models/queued_process.js";
 import type { FileFormat } from "../../src/types/file_format.js";
 import type { DownloadedFileProcessDetails } from "../../src/types/queued_process_details.js";
@@ -117,6 +121,33 @@ describe("Files", () => {
 
 		expect(process.type).to.eq("file-import");
 		expect(process.status).to.eq("queued");
+	});
+
+	it("uploads from FSS", async () => {
+		const params: UploadFileFromFssParams = {
+			fss_file_id: "0195c7a2-8f2e-7c3a-b4d5-123456789abc",
+			filename: "test_node.json",
+			lang_iso: "en",
+			format: "json",
+		};
+
+		const stub = new Stub({
+			fixture: "files/upload_from_fss.json",
+			uri: `projects/${projectId}/files/upload-from-fss`,
+			body: params as unknown as Record<string, unknown>,
+			method: "POST",
+		});
+
+		await stub.setStub();
+
+		const process: QueuedProcess = await lokaliseApi
+			.files()
+			.uploadFromFss(projectId, params);
+
+		expect(process.process_id).to.eq(processId);
+		expect(process.type).to.eq("file-import");
+		expect(process.status).to.eq("queued");
+		expect(process.created_by).to.eq(20181);
 	});
 
 	it("raises error for malformed response", async () => {

--- a/test/fixtures/files/upload_from_fss.json
+++ b/test/fixtures/files/upload_from_fss.json
@@ -1,0 +1,14 @@
+{
+	"project_id": "803826145ba90b42d5d860.46800099",
+	"branch": "master",
+	"process": {
+		"process_id": "8c951f34fcea49ad5647bc811fc59e1c9a485082",
+		"type": "file-import",
+		"status": "queued",
+		"message": "",
+		"created_by": 20181,
+		"created_by_email": "bodrovis@protonmail.com",
+		"created_at": "2023-09-21 11:33:19 (Etc/UTC)",
+		"created_at_timestamp": 1695295999
+	}
+}


### PR DESCRIPTION
### Summary
Adds support for the new POST /projects/{project_id}/files/upload-from-fss endpoint via lokaliseApi.files().uploadFromFss(project_id, params).

The method queues an import of a file previously uploaded to the Lokalise file storage service (FSS): instead of passing the file content as base64-encoded data, the file is referenced by fss_file_id. All other upload options are identical to the existing upload() method, and the response is the same QueuedProcess that can be polled via queuedProcesses().get().

Changes:

New uploadFromFss() method on the Files collection
New UploadFileFromFssParams type (UploadFileParams without data, plus fss_file_id), exported from the package root
Test with fixture (files/upload_from_fss.json) mirroring the existing upload spec
Docs section in docs/api/files.md
No bug fixes; purely additive, no breaking changes.